### PR TITLE
Walkthrough of the Repository

### DIFF
--- a/walkthrough.ipynb
+++ b/walkthrough.ipynb
@@ -1,0 +1,1950 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# 🔎 Practical Walkthrough: Information Retrieval with pv211-utils\n",
+    "\n",
+    "Welcome to this walkthrough notebook for the [**pv211-utils**](https://github.com/MIR-MU/pv211-utils) — an open-source Python library that provides an object-oriented interface for building and evaluating information retrieval search engines for various text collections. It is designed to help you implement and experiment with concepts from PV211: Introduction to Information Retrieval course taught at the Faculty of Informatics, Masaryk University, Brno, Czech Republic. \n",
+    "\n",
+    "\n",
+    "Code implementations here are mostly linked to concepts from the book [Introduction to Information Retrieval](https://nlp.stanford.edu/IR-book/) by Manning, Raghavan, & Schütze (2008). You can download the full PDF version [HERE](https://nlp.stanford.edu/IR-book/pdf/irbookonlinereading.pdf).\n",
+    "\n",
+    "\n",
+    "- Starting off (cloning and setting up the repo) -> [Click here](#starting-off)\n",
+    "- Projects from `notebooks` package (Cranfield, ARQMath, CQADupStack, TREC) -> [Click here](#projects-from-notebooks-package-cranfield-arqmath-cqadupstack-trec)\n",
+    "- To find out how to load the datasets -> [Click here](#working-with-datasets)\n",
+    "- Loading data for projects with the `datasets` module -> [Click here](#loading-data-for-projects-with-the-datasets-module)\n",
+    "- Information Retrieval Systems from `systems` package-> [Click here](#information-retrieval-systems-from-systems-package)\n",
+    "\n",
+    "\n",
+    "---\n",
+    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Starting off\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\n",
+    "\n",
+    "\n",
+    "## How to access the repository?\n",
+    "\n",
+    "You can find the official repository here:  \n",
+    "\n",
+    "🔗**GitHub:** [https://github.com/MIR-MU/pv211-utils](https://github.com/MIR-MU/pv211-utils)\n",
+    "\n",
+    "🔗**GitLab:** [https://gitlab.fi.muni.cz/xstefan3/pv211-utils](https://gitlab.fi.muni.cz/xstefan3/pv211-utils)\n",
+    "\n",
+    "Clone it to your local machine with:\n",
+    "\n",
+    "```bash\n",
+    "git clone https://github.com/username/reponame.git\n",
+    "```\n",
+    "\n",
+    "or\n",
+    "\n",
+    "```bash\n",
+    "git clone https://gitlab.fi.muni.cz/xstefan3/pv211-utils.git\n",
+    "```\n",
+    "\n",
+    "**(!)** Or... you can find other options for cloning the repo (SSH/KRB5) by following the links above."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Look around the repo: here are some useful files\n",
+    "\n",
+    "\n",
+    "- ###  `README.md`\n",
+    "\n",
+    "    This is the main documentation file for the repo. It contains a short descriptio, and... \n",
+    "\n",
+    "    **(!)** Here you can find direct links to every project both in Google Colab and Jupyter Hub\n",
+    "    - First Term Project: Cranfield Collection (23.24% MAP score) \n",
+    "\n",
+    "    - Second Term Project: Beir CQADupStack Collection (21.96% MAP score) \n",
+    "\n",
+    "    - Alternative Second Term Project: ARQMath Collection (6.62% MAP score) \n",
+    "\n",
+    "    - Pre-2023 Second Term Project: TREC Collection (43.06% MAP score)\n",
+    "\n",
+    "\n",
+    "- ### `requirements.txt`\n",
+    "\n",
+    "    Here you can find all the packages used in the repository.  \n",
+    "    To install all dependencies, you can run:\n",
+    "\n",
+    "    ```bash\n",
+    "    pip install -r requirements.txt\n",
+    "    ```\n",
+    "\n",
+    "    For more details, check the ```README.md``` in the repository root.\n",
+    "\n",
+    "\n",
+    "- ### `setup.py`\n",
+    "\n",
+    "    This script\n",
+    "    - defines how the `pv211-utils` package is built, installed, and distributed;\n",
+    "    - specifies the package metadata (name, version, author);\n",
+    "    - includes optional extras for notebooks or Google Drive downloads\n",
+    "\n",
+    "    **(!)** This is an alternative way to **install all dependencies**! \n",
+    "    \n",
+    "    - Just run `pip install .` in the repository root. Then `setup.py` will install everything needed for the library.\n",
+    "\n",
+    "\n",
+    "\n",
+    " - ### `spreadsheet`\n",
+    "\n",
+    "    These are the systems thar are responsible for the leaderboars for the projects. These leaderbords are linked to the spreadsheets that you can access from IS MUNI.\n",
+    "    Here you can find:\n",
+    "    - **README.md**:  includes archived leaderbords from the previous years \n",
+    "    - **dynamic-sorting.gs** is a Google Apps Script which keeps the leaderboard spreadsheets updated and sorted.\n",
+    "\n",
+    " \n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Projects from `notebooks` package (Cranfield, ARQMath, CQADupStack, TREC)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**In the `notebooks` folder you can find `.ipynb` files with the projects which are part of the PV211 course.**\n",
+    "\n",
+    "**Notebooks with the projects contain simple, baseline solutions. Here are the projects and the current scores:**\n",
+    "\n",
+    "\n",
+    "- **First Term Project: Cranfield Collection** (23.24% MAP score) -> open in [Google Colab](https://colab.research.google.com/github/MIR-MU/pv211-utils/blob/spring2025/notebooks/cranfield.ipynb) or [JupyterHub](https://iirhub.cloud.e-infra.cz/)\n",
+    "\n",
+    "- **Second Term Project: Beir CQADupStack Collection** (21.96% MAP score) -> open in [Google Colab](https://colab.research.google.com/github/MIR-MU/pv211-utils/blob/main/notebooks/beir_cqadupstack.ipynb) or [JupyterHub](https://iirhub.cloud.e-infra.cz/)\n",
+    "\n",
+    "- **Alternative Second Term Project: ARQMath Collection** (6.62% MAP score) -> open in [Google Colab](https://colab.research.google.com/github/MIR-MU/pv211-utils/blob/main/notebooks/arqmath.ipynb) or [JupyterHub](https://iirhub.cloud.e-infra.cz/)\n",
+    "\n",
+    "- **Pre-2023 Second Term Project: TREC Collection** (43.06% MAP score)-> open in [Google Colab](https://colab.research.google.com/github/MIR-MU/pv211-utils/blob/main/notebooks/trec.ipynb) or [JupyterHub](https://iirhub.cloud.e-infra.cz/)\n",
+    "\n",
+    "\n",
+    "⚠️ When working on the projects, don't forget to [keep the code clean](#recommended-resources-to-work-on-the-projects) and upload the `.ipynb` file to the Home Vault in IS MU. \n",
+    "\n",
+    "P.S. More detailed instructions are provided in the notebooks (links above)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Recommended resources to work on the projects\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\n",
+    "---\n",
+    "- **Documentation and coding style frameworks**\n",
+    "\n",
+    "    - **[PEP 8](https://www.python.org/dev/peps/pep-0008/)** – the official Python style guide for consistent code formatting, naming, indentation, line lengths, etc.\n",
+    "\n",
+    "    - **[PEP 257](https://www.python.org/dev/peps/pep-0257/)** – conventions for writing clear, concise, and structured Python docstrings.\n",
+    "\n",
+    "    - **[NumPy Docstring Standard](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard)** – a widely adopted style for writing detailed, sectioned docstrings, especially in scientific and data projects.\n",
+    "\n",
+    "    - **[Google Python Style Guide](https://google.github.io/styleguide/pyguide.html)** – an alternative coding and docstring style guide, simpler than NumPy style but still structured.\n",
+    "\n",
+    "    - **[reStructuredText (reST)](https://docutils.sourceforge.io/rst.html)** – the markup syntax used in many Python docstrings to format text with headings, lists, links, etc.\n",
+    "\n",
+    "\n",
+    "\n",
+    "---\n",
+    "\n",
+    "- **Notebook environments you may use:**\n",
+    "\n",
+    "    - **[Google Colab](https://colab.research.google.com/)** – free, cloud-hosted Jupyter notebooks with GPU/TPU support.\n",
+    "\n",
+    "    - **[DeepNote](https://deepnote.com/)** – collaborative cloud notebooks with modern UI.\n",
+    "\n",
+    "    - **[JupyterHub](https://iirhub.cloud.e-infra.cz/)** – preconfigured with course resources, allowing you to run pv211-utils notebooks in a set up environment\n",
+    "\n",
+    "    - **[Kaggle Notebooks](https://www.kaggle.com/code)** – cloud notebooks with integrated datasets\n",
+    "\n",
+    "\n",
+    "---\n",
+    "\n",
+    "- **(!)** If you prefer working on your code locally, here are some useful links:\n",
+    "\n",
+    "    - **[JupyterLab](https://jupyter.org/)** – interface for running Jupyter notebooks locally, with tabs, terminals, and some really nice extensions.\n",
+    "\n",
+    "    - **[VS Code Notebooks](https://code.visualstudio.com/docs/datascience/jupyter-notebooks)** – run, edit, and debug notebooks directly in VS Code, with integrated linting and formatting.\n",
+    "\n",
+    "- ...and some frameworks to keep your code clean and work locally:\n",
+    "\n",
+    "    - [flake8](https://flake8.pycqa.org/en/latest/) – checks your code for style issues and simple bugs.\n",
+    "\n",
+    "    - [pydocstyle](https://www.pydocstyle.org/en/stable/) – checks your docstrings follow good conventions.\n",
+    "\n",
+    "    - [black](https://black.readthedocs.io/en/stable/) – auto-formats your code so it always looks neat.\n",
+    "\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Cranfield Collection"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\n",
+    "Your task is to implement an unsupervised ranked retrieval system, which will produce a list of documents from the Cranfield collection in a descending order of relevance to a queryYou are going to work with the **Cranfield Collection**.  It might be the most famous and fundamental test collection in the field of Information Retrieval. It was developed in the United Kingdom at the Cranfield Institute of Technology in the late 1950s and early 1960s. In fact, it was the first collection designed to systematically evaluate information retrieval systems.\n",
+    "\n",
+    "It contains:\n",
+    "- **1398 abstracts** of journal articles about **aerodynamics and engineering**.\n",
+    "- **225 queries** crafted to test the IR systems\n",
+    "- **Relevance judgements**  that specify, for every query-document pair, whether the document is relevant to the query.\n",
+    "\n",
+    "    (!) Cranfield judgments are binary: either a document is relevant (included in the judgements) or not relevant (absent from the set of judgements).\n",
+    "\n",
+    "\n",
+    "\n",
+    "**-> The Cranfield Collection** was described in the book by Manning et al. in [Section 8.2](https://nlp.stanford.edu/IR-book/pdf/08eval.pdf). In this section you can also read about the evaluation process of IR systems.\n",
+    "\n",
+    "**->** You can work on this project using any tool mentioned above. Here are direct links to [Google Colab](https://colab.research.google.com/github/MIR-MU/pv211-utils/blob/spring2025/notebooks/cranfield.ipynb) and [JupyterHub](https://iirhub.cloud.e-infra.cz/)\n",
+    "\n",
+    "**->** if you have any trouble loading the collection, visit the [datasets.py](#loading-the-data-for-the-projects-with-the-datasetspy-module) module section.\n",
+    "\n",
+    "**Let's take a look at the data from the Cranfield just to see how it all works... For a more deep demo check out the notebook directly :)**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "c:\\Users\\Admin\\Python311\\Lib\\site-packages\\beir\\util.py:11: TqdmExperimentalWarning: Using `tqdm.autonotebook.tqdm` in notebook mode. Use `tqdm.tqdm` instead to force console mode (e.g. in jupyter console)\n",
+      "  from tqdm.autonotebook import tqdm\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Test split size: 0.2\n",
+      "Validation split size: 0.1\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pv211_utils.datasets import CranfieldDataset\n",
+    "\n",
+    "# Initializing the dataset and setting the test and validation split\n",
+    "cranfield = CranfieldDataset(test_split_size=0.2)\n",
+    "cranfield.set_validation_split_size(0.1)\n",
+    "print(f\"Test split size: {cranfield.test_split_size}\")\n",
+    "print(f\"Validation split size: {cranfield.validation_split_size}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Total documents: 1400\n",
+      "Total test queries: 162\n",
+      "Total train judgments: 1340\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Checking out the number of the documens and queries\n",
+    "# Loading documents, queries, and judgements\n",
+    "documents = cranfield.load_documents()\n",
+    "queries = cranfield.load_train_queries()\n",
+    "judgements = list(cranfield.load_train_judgements())\n",
+    "\n",
+    "print(f\"Total documents: {len(documents)}\")\n",
+    "print(f\"Total test queries: {len(queries)}\")\n",
+    "print(f\"Total train judgments: {len(judgements)}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Let's see what we have here...\n",
+      "\n",
+      "Picked judgment index: 21\n",
+      "\n",
+      "Query ID: 68\n",
+      "Query text:\n",
+      "what possible techniques are available for computing the injection distribution corresponding to an isothermal transpiration cooled hemisphere .\n",
+      "\n",
+      "Document ID: 628\n",
+      "Document body:\n",
+      "...thermal effects on a transpiration cooled hemisphere .   an approximate method is used to obtain the injection distribution which would exist on an isothermal, transpiration-cooled hemisphere in a supersonic stream . this distribution is the same for both air and helium injection, and is independent of the blowing level .  a model having this distribution was tested in the naval supersonic laboratory wind tunnel at a mach number of 3.53 .  it is concluded that the design technique is reasonably ...\n"
+     ]
+    }
+   ],
+   "source": [
+    "# accessing the documents and queries\n",
+    "# pick a judgment (enter an index like 0,1,2, 5 etc.)\n",
+    "index = 21\n",
+    "query, document = judgements[index]\n",
+    "\n",
+    "# printing the given judgement, query and the document\n",
+    "print(f\"Let's see what we have here...\\n\")\n",
+    "print(f\"Picked judgment index: {index}\\n\")\n",
+    "print(f\"Query ID: {query.query_id}\")\n",
+    "print(f\"Query text:\\n{query.body.strip()}\\n\")\n",
+    "print(f\"Document ID: {document.document_id}\")\n",
+    "print(f\"Document body:\\n...{document.body.strip()[:500]}...\")\n",
+    "\n",
+    "# this document should be relevant for the given query - check it yourself :)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now that you saw the data on your own eyes, it's time to go to the notebook and build a nice Information Retrieval system on top of it."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## CQADupStack Collection"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Your task is to implement an unsupervised ranked retrieval system, which will produce a list of documents from the **CQADupStack Collection** in a descending order of relevance to a query.\n",
+    "\n",
+    "You are going to work with the **CQADupStack Collection**, a benchmark dataset for community question-answering research. It is part of the larger [BEIR benchmark collection](https://github.com/beir-cellar/beir), and was introduced by Hoogeveen et al. (2015) as \"[a] Benchmark Data Set for Community Question-Answering Research.\"\n",
+    "\n",
+    "CQADupStack contains data from **12 different [Stack Exchange](https://stackexchange.com/) subforums**, each consisting of real-world user questions and corresponding answers. \n",
+    "It contains:\n",
+    "- **Community QA pairs** from topics like Android, English, Gaming, GIS, Mathematica, Physics, Programmers, Stats, TeX, Unix, Webmasters, and WordPress.\n",
+    "- **Queries** are real user questions from Stack Exchange forums.\n",
+    "- **Documents** are candidate duplicate questions and answers within the same subforum.\n",
+    "- **Relevance judgements** specify which documents (questions/answers) are considered duplicates of a given query.\n",
+    "\n",
+    "    (!) CQADupStack judgments are **binary**: either a document is considered a duplicate (relevant) or it is not.\n",
+    "\n",
+    "Your tasks, reviewed by your colleagues and course instructors, are the following:\n",
+    "- Implement a ranked retrieval system that produces a list of documents from CQADupStack in descending order of relevance to each query, as described in [Manning et al., Chapter 6](https://nlp.stanford.edu/IR-book/pdf/06vect.pdf).\n",
+    "- Document your code in accordance with [PEP 257](https://peps.python.org/pep-0257/), ideally using [the NumPy style guide](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard). Stick to a consistent coding style following [PEP 8](https://peps.python.org/pep-0008/).\n",
+    "- Reach at least **25% mean average precision at 10** (MAP@10) on the CQADupStack collection, as described in [Manning et al., Section 8.4](https://nlp.stanford.edu/IR-book/pdf/08eval.pdf).\n",
+    "- Upload your `.ipynb` notebook to the homework vault in IS MU. Optionally, include a brief description of your retrieval system and a link to an external service such as Google Colaboratory, DeepNote, or JupyterHub.\n",
+    "\n",
+    "**-> The CQADupStack dataset is described in detail in [Hoogeveen et al., 2015](https://dl.acm.org/doi/10.1145/2838931.2838934), and is included in the BEIR benchmark described on the [BEIR GitHub page](https://github.com/beir-cellar/beir).**\n",
+    "\n",
+    "**->** You can work on this project using any tool mentioned above. Here are direct links to [Google Colab](https://colab.research.google.com/github/MIR-MU/pv211-utils/blob/main/notebooks/beir_cqadupstack.ipynb) and [JupyterHub](https://iirhub.cloud.e-infra.cz/)\n",
+    "\n",
+    "**->** If you have trouble loading the collection, visit the [datasets.py module section](#loading-the-data-for-the-projects-with-the-datasetspy-module).\n",
+    "\n",
+    "**Let's take a look at the data from CQADupStack just to see how it all works… For a deeper demo, check out the notebook directly :)**\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loaded BEIR dataset: quora\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pv211_utils.datasets import BeirDataset\n",
+    "\n",
+    "# initializing the BEIR dataset; replace with any available BEIR dataset name\n",
+    "dataset_name = \"quora\"  # e.g., msmarco, hotpotqa, nq, fever, etc.\n",
+    "beir = BeirDataset(dataset_name=dataset_name)\n",
+    "\n",
+    "print(f\"Loaded BEIR dataset: {beir.dataset_name}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e95b12d48c664f3bad1cda3c0c4b0a8e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/522931 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "80c17b63e7124bef81f23d4707136237",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/522931 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "b8c21272e51944cf812a07015c7812b7",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/522931 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Total documents: 522931\n",
+      "Total train queries: 10000\n",
+      "Total train judgments: 15675\n"
+     ]
+    }
+   ],
+   "source": [
+    "# loading documents, queries, and judgments\n",
+    "# NOTICE: some datasets may not have train sets, so better call for test sets\n",
+    "documents = beir.load_documents()\n",
+    "queries = beir.load_test_queries()\n",
+    "judgements = list(beir.load_test_judgements())\n",
+    "\n",
+    "print(f\"Total documents: {len(documents)}\")\n",
+    "print(f\"Total train queries: {len(queries)}\")\n",
+    "print(f\"Total train judgments: {len(judgements)}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Let's see what we have here...\n",
+      "\n",
+      "Picked judgment index: 211\n",
+      "\n",
+      "Query ID: 307111\n",
+      "Query text:\n",
+      "How can we make this world visa and border free with a centralised government ?\n",
+      "\n",
+      "Document ID: 517573\n",
+      "Document body:\n",
+      "...How can we make this world visa free?...\n"
+     ]
+    }
+   ],
+   "source": [
+    "# accessing the documents and queries\n",
+    "# pick a judgment (enter an index like 0,1,2,5 etc.)\n",
+    "index = 211\n",
+    "query, document = judgements[index]\n",
+    "\n",
+    "# cleaning the document body for better readability\n",
+    "import re\n",
+    "cleaned_doc_body = re.sub(r'\\s+', ' ', document.body).strip()\n",
+    "\n",
+    "print(f\"Let's see what we have here...\\n\")\n",
+    "print(f\"Picked judgment index: {index}\\n\")\n",
+    "print(f\"Query ID: {query.query_id}\")\n",
+    "print(f\"Query text:\\n{query.body.strip()}\\n\")\n",
+    "print(f\"Document ID: {document.document_id}\")\n",
+    "print(f\"Document body:\\n...{cleaned_doc_body}...\")\n",
+    "\n",
+    "\n",
+    "# Reminder: This document is judged relevant to the query — check if it makes sense!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## ARQMath Collection"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Your task is to implement a supervised ranked retrieval system, which will produce a list of documents from the **ARQMath Collection** in a descending order of relevance to a query.\n",
+    "\n",
+    "You are going to work with the **ARQMath Collection**, a benchmark dataset focused on mathematical question answering. ARQMath uses real threads from the Math Stack Exchange site and aims to advance math-aware search systems capable of understanding both **text** and **mathematical notation** in questions and answers.\n",
+    "\n",
+    "According to [Zanibbi et al., 2020](https://ceur-ws.org/Vol-2696/paper_271.pdf), ~20% of math-related queries submitted to general-purpose search engines are well-formed questions, highlighting the real need for effective math question answering systems.\n",
+    "\n",
+    "ARQMath contains:\n",
+    "- **Questions** posted on Math Stack Exchange.\n",
+    "- **Answers** submitted by the community, forming candidate documents.\n",
+    "- **Queries**, which are real math questions used to evaluate answer retrieval systems.\n",
+    "- **Relevance judgements**, specifying which answers are relevant to each query.\n",
+    "\n",
+    "    (!) ARQMath judgments use **graded relevance**, with relevance levels 0 (not relevant), 1 (partially relevant), or 2 (highly relevant). You should use training and validation judgments for building your system, and test judgments only for evaluation.\n",
+    "\n",
+    " ![Answer Retrieval Task](https://www.cs.rit.edu/~dprl/ARQMath/assets/images/screen-shot-2019-09-09-at-11.11.57-pm-2656x1229.png)\n",
+    "\n",
+    "Your tasks, reviewed by your colleagues and course instructors, are the following:\n",
+    "- Implement a supervised ranked retrieval system that produces a ranked list of answers for each query, as described in [Manning et al., Chapter 15](https://nlp.stanford.edu/IR-book/pdf/15learn.pdf).\n",
+    "- Document your code in accordance with [PEP 257](https://peps.python.org/pep-0257/), ideally using [the NumPy style guide](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard). Stick to a consistent coding style following [PEP 8](https://peps.python.org/pep-0008/).\n",
+    "- Reach at least **10% mean average precision at 10** (MAP@10) on the ARQMath collection, as discussed in [Manning et al., Section 8.4](https://nlp.stanford.edu/IR-book/pdf/08eval.pdf).\n",
+    "- You are encouraged to use advanced IR techniques such as tokenization ([Section 2.2](https://nlp.stanford.edu/IR-book/pdf/02bool.pdf)), document representation ([Section 6.4](https://nlp.stanford.edu/IR-book/pdf/06vect.pdf)), tolerant retrieval ([Chapter 3](https://nlp.stanford.edu/IR-book/pdf/03edit.pdf)), relevance feedback, query expansion ([Chapter 9](https://nlp.stanford.edu/IR-book/pdf/09expand.pdf)), and learning to rank ([Chapter 15](https://nlp.stanford.edu/IR-book/pdf/15learn.pdf)).\n",
+    "\n",
+    "- Upload your `.ipynb` notebook to the homework vault in IS MU. Optionally, include a brief description of your system and a link to an external service like Google Colaboratory, DeepNote, or JupyterHub.\n",
+    "\n",
+    "**-> The ARQMath Collection is described in detail in [Zanibbi et al., 2022](https://www.cs.rit.edu/~dprl/ARQMath/index.html) and focuses on developing math-aware retrieval systems for community Q&A sites.**\n",
+    "\n",
+    "**->** You can work on this project using any of the recommended tools above. Here are direct links to [Google Colab](https://colab.research.google.com/github/MIR-MU/pv211-utils/blob/spring2025/notebooks/arqmath.ipynb) and [JupyterHub](https://iirhub.cloud.e-infra.cz/).\n",
+    "\n",
+    "**->** If you have trouble loading the collection, visit the [datasets.py module section](#loading-the-data-for-the-projects-with-the-datasetspy-module).\n",
+    "\n",
+    "---\n",
+    "\n",
+    "### ARQMath dataset configuration\n",
+    "\n",
+    "- **Years available for splitting**: 2020, 2021, 2022. Choose one year as the **test set**; the other two form the training set.\n",
+    "- **Validation split**: obtained by further splitting the training set.\n",
+    "- **Text formats** available for representing math content:\n",
+    "  - `text`: Plain text without math.\n",
+    "  - `text+latex`: Text + LaTeX math (with `$...$`).\n",
+    "  - `text+prefix`: Text + Tangent-L’s prefix math representation.\n",
+    "  - `text+tangentl`: Text + math in Tangent-L’s mathtuples.\n",
+    "  - `xhtml+latex`: XHTML + LaTeX.\n",
+    "  - `xhtml+pmml`: XHTML + Presentation MathML.\n",
+    "  - `xhtml+cmml`: XHTML + Content MathML.\n",
+    "\n",
+    "**Now let's explore some code on this...**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Test year: 2020\n",
+      "Text format: text+latex\n",
+      "Validation split size: 0.1\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pv211_utils.datasets import ArqmathDataset\n",
+    "import re\n",
+    "\n",
+    "# initializing ARQMath dataset for 2020 as the test year...\n",
+    "# choose a text format that includes math notation (all of them are listed above)\n",
+    "arqmath = ArqmathDataset(year=2020, text_format=\"text+latex\", validation_split_size=0.1)\n",
+    "\n",
+    "print(f\"Test year: {arqmath.year}\")\n",
+    "print(f\"Text format: {arqmath.text_format}\")\n",
+    "print(f\"Validation split size: {arqmath.validatoin_split_size}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Computing MD5: C:\\Users\\Admin\\.cache\\pv211-utils\\75975b2833889cc12007251c3b5de951\n",
+      "MD5 matches: C:\\Users\\Admin\\.cache\\pv211-utils\\75975b2833889cc12007251c3b5de951\n",
+      "Computing MD5: C:\\Users\\Admin\\.cache\\pv211-utils\\75975b2833889cc12007251c3b5de951\n",
+      "MD5 matches: C:\\Users\\Admin\\.cache\\pv211-utils\\75975b2833889cc12007251c3b5de951\n",
+      "Total answers (documents): 1445495\n",
+      "Total train queries: 77\n",
+      "Total train judgements: 1804\n"
+     ]
+    }
+   ],
+   "source": [
+    "# loading documents (answers), queries, and judgements\n",
+    "answers = arqmath.load_answers()\n",
+    "queries = arqmath.load_test_queries()\n",
+    "judgements = list(arqmath.load_test_judgements())\n",
+    "\n",
+    "print(f\"Total answers (documents): {len(answers)}\")\n",
+    "print(f\"Total train queries: {len(queries)}\")\n",
+    "print(f\"Total train judgements: {len(judgements)}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Let's see what we have here...\n",
+      "\n",
+      "Picked judgement index: 211\n",
+      "\n",
+      "Query ID: 27\n",
+      "Query text:\n",
+      "When solving for the value, we know that $e^{\\pi i}=-1$ . I am confused as to what is the right answer when you evaluate this.I am getting two possible answers: $e^{3\\pi i/2}$ = $(e^{\\pi i})^{3/2}$ so this could be $(\\sqrt{-1})^3=i^3=-i$ or it could be $\\sqrt{(-1)^3}=\\sqrt{-1}=i$. Which one is the correct answer, and where am I going wrong? Thanks.\n",
+      "\n",
+      "Answer ID: 1240563\n",
+      "Answer body:\n",
+      "...The trick is Euler's formula: $e^{i \\theta}=\\cos(\\theta)+i\\sin(\\theta).$ Multiplying by a factor of $r&gt;0$ you get the polar form of a general complex number: $r e^{i \\theta}=r \\cos(\\theta) + ir\\sin(\\theta)$. This form is really nice for roots, because the rules for exponents of real numbers carry over here, with some caveats. For instance, let's look at $\\sqrt[3]{-1+i}$. One way to write $-1+i$ would be $\\sqrt{2} e^{i 3 \\pi/4}$. If you now take its third root in this form, you use the exponen...\n"
+     ]
+    }
+   ],
+   "source": [
+    "\n",
+    "# picking a judgement to inspect: you can change the index to whatever you think is a nice number\n",
+    "index = 211\n",
+    "query, answer = judgements[index]\n",
+    "\n",
+    "# some regex magic here to make outputs more readable\n",
+    "cleaned_answer_body = re.sub(r'\\s+', ' ', answer.body).strip()\n",
+    "\n",
+    "print(f\"Let's see what we have here...\\n\")\n",
+    "print(f\"Picked judgement index: {index}\\n\")\n",
+    "print(f\"Query ID: {query.query_id}\")\n",
+    "print(f\"Query text:\\n{query.body.strip()}\\n\")\n",
+    "print(f\"Answer ID: {answer.document_id}\")\n",
+    "print(f\"Answer body:\\n...{cleaned_answer_body[:500]}...\")\n",
+    "\n",
+    "# reminder: The retrieved answer was judged relevant to this query, so it should make sense.\n",
+    "# even though it can be a LaTeX coe (not very readable), you can still copy it to e.g Overleaf and see how it is related with the query."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## TREC Collection"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Your task is to implement a supervised ranked retrieval system, which will produce a list of documents from the **TREC Collection** in a descending order of relevance to a query.\n",
+    "\n",
+    "You are going to work with the **TREC Collection**, one of the most influential benchmarks in Information Retrieval, developed by the U.S. National Institute of Standards and Technology (NIST) as part of the Text REtrieval Conference (TREC) series starting in 1992(yes, that's where the name from))\n",
+    "\n",
+    "According to [Manning et al., Section 8.2](https://nlp.stanford.edu/IR-book/pdf/08eval.pdf), TREC datasets such as TRECs 6–8 include **150 information needs (queries)** over about **528,000 newswire and Foreign Broadcast Information Service articles**, creating one of the largest and most realistic testbeds for large-scale information retrieval systems.\n",
+    "\n",
+    "The TREC Collection contains:\n",
+    "- Hundreds of thousands of **documents** from real newswire and broadcast sources.\n",
+    "- **Queries** reflecting realistic information needs (information requests) posed to the system.\n",
+    "- **Relevance judgements**, connecting queries with relevant documents, though not exhaustive due to the scale of the collection.\n",
+    "\n",
+    "    (!) Because the collection is so large, TREC judgments are **incomplete**: not all documents have been manually judged for every query. This means that mean average precision metrics assume unjudged documents are not relevant.\n",
+    "---\n",
+    "Your tasks, reviewed by your colleagues and course instructors, are the following:\n",
+    "- Implement a supervised ranked retrieval system that produces a ranked list of documents for each query, as described in [Manning et al., Chapter 15](https://nlp.stanford.edu/IR-book/pdf/15learn.pdf).\n",
+    "- Document your code in accordance with [PEP 257](https://peps.python.org/pep-0257/), ideally using [the NumPy style guide](https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard). Stick to a consistent coding style following [PEP 8](https://peps.python.org/pep-0008/).\n",
+    "- Reach at least **13.5% mean average precision at 10** (MAP@10) on the TREC collection, as discussed in [Manning et al., Section 8.4](https://nlp.stanford.edu/IR-book/pdf/08eval.pdf).\n",
+    "- You are encouraged to apply techniques such as tokenization ([Section 2.2](https://nlp.stanford.edu/IR-book/pdf/02bool.pdf)), document representation ([Section 6.4](https://nlp.stanford.edu/IR-book/pdf/06vect.pdf)), tolerant retrieval ([Chapter 3](https://nlp.stanford.edu/IR-book/pdf/03edit.pdf)), relevance feedback, query expansion ([Chapter 9](https://nlp.stanford.edu/IR-book/pdf/09expand.pdf)), and learning to rank ([Chapter 15](https://nlp.stanford.edu/IR-book/pdf/15learn.pdf)).\n",
+    "\n",
+    "- Upload your `.ipynb` notebook to the homework vault in IS MU. Optionally, include a brief description of your system and a link to an external service like [Google Colaboratory](https://colab.research.google.com/), [DeepNote](https://deepnote.com/), or [JupyterHub](https://iirhub.cloud.e-infra.cz/).\n",
+    "---\n",
+    "\n",
+    "**-> The TREC Collection is described in detail in [Manning et al., Section 8.2](https://nlp.stanford.edu/IR-book/pdf/08eval.pdf) and serves as a key resource for evaluating large-scale IR systems on real-world news content.**\n",
+    "\n",
+    "**->** You can work on this project using any recommended tools above. Here are direct links to [Google Colab](https://colab.research.google.com/github/MIR-MU/pv211-utils/blob/spring2025/notebooks/trec.ipynb) and [JupyterHub](https://iirhub.cloud.e-infra.cz/).\n",
+    "\n",
+    "**->** If you have trouble loading the collection, visit the [datasets.py module section](#loading-the-data-for-the-projects-with-the-datasetspy-module).\n",
+    "\n",
+    "---\n",
+    "\n",
+    "You can observe some data from the TREC Collection below.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Validation split size: 0.1\n",
+      "Computing MD5: C:\\Users\\Admin\\.cache\\pv211-utils\\a75c5f3f7f75085c94f111594ba7d227\n",
+      "MD5 matches: C:\\Users\\Admin\\.cache\\pv211-utils\\a75c5f3f7f75085c94f111594ba7d227\n",
+      "Loaded 527890 documents.\n",
+      "Loaded 50 test queries.\n",
+      "Computing MD5: C:\\Users\\Admin\\.cache\\pv211-utils\\a75c5f3f7f75085c94f111594ba7d227\n",
+      "MD5 matches: C:\\Users\\Admin\\.cache\\pv211-utils\\a75c5f3f7f75085c94f111594ba7d227\n",
+      "Loaded 4726 test judgements.\n",
+      "\n",
+      "Let's see what we have here...\n",
+      "\n",
+      "Picked judgement index: 0\n",
+      "\n",
+      "Query ID: 402\n",
+      "Query text:\n",
+      "What is happening in the field of behavioral genetics,\n",
+      "the study of the relative influence of genetic\n",
+      "and environmental factors on an individual's behavior\n",
+      "or personality?\n",
+      "\n",
+      "Document ID: FT932-13552\n",
+      "Document snippet:\n",
+      "...PHARMACEUTICAL research will be transformed over the next two decades through the development of drugs that act directly on human genes. Almost all today's drugs act on proteins, the chemicals that do the work in every living creature from virus to human. But the rapid expansion of genetic knowledge makes it possible to target the original cause of trouble -the genes that determine exactly which proteins the cells make. Every week the world's molecular biologists announce the discovery of new ge...\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pv211_utils.datasets import TrecDataset\n",
+    "import re\n",
+    "\n",
+    "# creating the TREC dataset with validation split\n",
+    "trec = TrecDataset(validation_split_size=0.1)\n",
+    "\n",
+    "print(f\"Validation split size: {trec.validation_split_size}\")\n",
+    "\n",
+    "# loading documents\n",
+    "documents = trec.load_documents()\n",
+    "print(f\"Loaded {len(documents)} documents.\")\n",
+    "\n",
+    "# loading test queries\n",
+    "queries = trec.load_test_queries()\n",
+    "print(f\"Loaded {len(queries)} test queries.\")\n",
+    "\n",
+    "# loading test judgements\n",
+    "judgements = list(trec.load_test_judgements())\n",
+    "print(f\"Loaded {len(judgements)} test judgements.\")\n",
+    "\n",
+    "\n",
+    "index = 0\n",
+    "query, document = judgements[index]\n",
+    "\n",
+    "# cleaning the document text for display\n",
+    "cleaned_doc_text = re.sub(r'\\s+', ' ', document.body).strip()\n",
+    "\n",
+    "print(f\"\\nLet's see what we have here...\\n\")\n",
+    "print(f\"Picked judgement index: {index}\\n\")\n",
+    "print(f\"Query ID: {query.query_id}\")\n",
+    "print(f\"Query text:\\n{query.body.strip()}\\n\")\n",
+    "print(f\"Document ID: {document.document_id}\")\n",
+    "print(f\"Document snippet:\\n...{cleaned_doc_text[:500]}...\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Loading data for projects with the `datasets` module\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The datasets.py module provides a unified, simple interface to work with datasets:\n",
+    "\n",
+    "- ARQMath   ---> *[ detailed demo...](#cranfield-collection)*\n",
+    "- Cranfield   --->  *[detailed demo...](#cqadupstack-collection)*\n",
+    "- TREC   --->   *[detailed demo...](#arqmath-collection)*\n",
+    "- BEIR    --->  *[detailed demo...](#trec-collection)*\n",
+    "\n",
+    "You can find more detailed demonstrations of working with each dataset in the [Notebooks](#notebooks) section.\n",
+    "\n",
+    "\n",
+    "The `datasets` module encapsulates each dataset in a class, considering dataset-specific logic to retrieve queries, documents, and relevance judgments while handling details like file downloads, data integrity, and split management (train/validation/test)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Loading a dataset: example with `CranfieldDataset`\n",
+    "\n",
+    "Here is an example of loading the Cranfield dataset and setting the train and test split. You can also find more detailed demo of working with Cranfield in [this section](#cranfield-collection)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Test split size: 0.2\n",
+      "Validation split size: 0.1\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pv211_utils.datasets import CranfieldDataset\n",
+    "\n",
+    "# creating a CranfieldDataset instance with a 20% test split and 10% validation split\n",
+    "cranfield = CranfieldDataset(test_split_size=0.2, validation_split_size=0.1)\n",
+    "print(f\"Test split size: {cranfield.test_split_size}\")\n",
+    "print(f\"Validation split size: {cranfield.validation_split_size}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "We loaded 162 training queries with 1340 relevance judgments.\n",
+      "We loaded 1400 documents from the Cranfield collection.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# loading training queries and judgments + documents\n",
+    "train_queries = cranfield.load_train_queries()\n",
+    "train_judgements = cranfield.load_train_judgements()\n",
+    "documents = cranfield.load_documents()\n",
+    "\n",
+    "print(f\"We loaded {len(train_queries)} training queries with {len(train_judgements)} relevance judgments.\")\n",
+    "print(f\"We loaded {len(documents)} documents from the Cranfield collection.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Loading data with `ArqmathDataset` and setting parameters\n",
+    "\n",
+    "ARQMath Collection procides:\n",
+    "- 3 years (2020-2021-2022) for train-test split (the year you choose becomes the test data)\n",
+    "- 7 text formats for representing math content.\n",
+    "\n",
+    "You can find available text formats and other datasets characteristics in [this section](#arqmath-collection)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ARQMath year: 2021, text format: text+latex\n",
+      "Loaded 100 test queries for ARQMath.\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pv211_utils.datasets import ArqmathDataset\n",
+    "\n",
+    "# let's set year 2021 and \"text+latex\" format\n",
+    "arqmath = ArqmathDataset(year=2021, text_format=\"text+latex\", validation_split_size=0.15)\n",
+    "print(f\"ARQMath year: {arqmath.year}, text format: {arqmath.text_format}\")\n",
+    "\n",
+    "# load test queries\n",
+    "test_queries = arqmath.load_test_queries()\n",
+    "print(f\"Loaded {len(test_queries)} test queries for ARQMath.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Preprocessing documents with the `text_preprocessing` and `math_preprocessing`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Before using text data in information retrieval systems, we need to preprocess it to make it more clean. Preprocessing helps by converting text to a consistent format, removing noise, and normalizing words, which improves both efficiency and retrieval quality.\n",
+    "\n",
+    "\n",
+    "*“It is standard to do some form of normalization on the tokens before indexing. The most standard is to case-fold all tokens down to lowercase... Often, people also remove punctuation, digits, and perform stemming or lemmatization.”*\n",
+    "\n",
+    "*(Introduction to Information Retrieval, [Section 2.2](https://nlp.stanford.edu/IR-book/pdf/02voc.pdf))*\n",
+    "\n",
+    "\n",
+    "The `text_preprocessing` module provides structured, reusable objects for this task. You can easily import classes like `DocPreprocessing` and configure options like lowercasing, accent removal, stop word filtering, stemming, and lemmatization — all in one place!\n",
+    "\n",
+    "The `math_preprocessing` module can help with math expressions (for example, in the ARQMath Collection project).\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Simple preprocessing\n",
+    "\n",
+    "Before moving to harder stuff, let's explore some really basic examples of how we can preprocess documents. We will use just one sentence as an example."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# feel free to type in any sentence that comes to your mind here\n",
+    "sentence = \"What a níce idéa to start my projéct 2 dáys beforé the deadliné... I hope it is not going to end with a defenestration\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Tokens with NoneDocPreprocessing:\n",
+      "['What', 'a', 'níce', 'idéa', 'to', 'start', 'my', 'projéct', '2', 'dáys', 'beforé', 'the', 'deadliné...', 'I', 'hope', 'it', 'is', 'not', 'going', 'to', 'end', 'with', 'a', 'defenestration']\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pv211_utils.preprocessing.text_preprocessing import NoneDocPreprocessing  # does nothing except splitting the sentence into words\n",
+    "\n",
+    "preprocessor = NoneDocPreprocessing()\n",
+    "tokens = preprocessor(sentence)\n",
+    "print(\"Tokens with NoneDocPreprocessing:\")\n",
+    "print(tokens)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Tokens with LowerDocPreprocessing:\n",
+      "['what', 'a', 'níce', 'idéa', 'to', 'start', 'my', 'projéct', '2', 'dáys', 'beforé', 'the', 'deadliné...', 'i', 'hope', 'it', 'is', 'not', 'going', 'to', 'end', 'with', 'a', 'defenestration']\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pv211_utils.preprocessing.text_preprocessing import LowerDocPreprocessing # splits the sentence and lowers each of them\n",
+    "\n",
+    "preprocessor = LowerDocPreprocessing()\n",
+    "tokens = preprocessor(sentence)\n",
+    "print(\"Tokens with LowerDocPreprocessing:\")\n",
+    "print(tokens)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Tokens with SimpleDocPreprocessing:\n",
+      "['what', 'nice', 'idea', 'to', 'start', 'my', 'project', 'days', 'before', 'the', 'deadline', 'hope', 'it', 'is', 'not', 'going', 'to', 'end', 'with']\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pv211_utils.preprocessing.text_preprocessing import SimpleDocPreprocessing # can use deacc (remove diacritics from the text) and filter words by length\n",
+    "\n",
+    "\n",
+    "# with deaccent enabled and max_len=12 we get a nice list of words without accents and without the words that are too long or too short\n",
+    "preprocessor = SimpleDocPreprocessing(deacc=True, min_len=2, max_len=12)\n",
+    "tokens = preprocessor(sentence)\n",
+    "print(\"Tokens with SimpleDocPreprocessing:\")\n",
+    "print(tokens)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Improved preprocessing with stop words, stemming and lemmatization\n",
+    "\n",
+    "Now let us explore it a bit further and see how we can customize the DocPreprocessing magic with...\n",
+    "1. Stop words\n",
+    "2. Stemming\n",
+    "3. Lemmatization\n",
+    "\n",
+    "You can perform these and other preprocessing techniques by importing `DocPreprocessing` object from the `text_preprocessing` module.\n",
+    "\n",
+    "**->** The process of text normalization, including all mentioned above, is further discussed in Manning et al. [Section 2.2](https://nlp.stanford.edu/IR-book/pdf/02voc.pdf). This section is really useful to read if you want to make a good preprocessing pipeline for your specific task. \n",
+    "\n",
+    "**->** Also, there are interesting introductory articles about this, for example Text Preprocessing with NLTK on [GeeksForGeeks](https://www.geeksforgeeks.org/nlp/removing-stop-words-nltk-python/) and a a more general article on text normalization on [Medium](https://medium.com/@prvaddkkepurakkal/text-preprocessing-in-nlp-19ebe6c9732c).\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Stop Words\n",
+    "\n",
+    "Stop words are common words which are of little value in helping select documents matching a user need. For example, in an English text corpus, words like `‘the’, ‘is’, ‘at’, ‘which’, and ‘on’` are typical stop words. Removing them can reduce the size of the index and improve efficiency. [Manning et al., Introduction to Information Retrieval, [Section 2.2](https://nlp.stanford.edu/IR-book/pdf/02voc.pdf)]."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Tokens with DocPreprocessing and the list of stopwords:\n",
+      "['what', 'nice', 'idea', 'start', 'project', 'days', 'before', 'the', 'deadline...', 'hope', 'going', 'end', 'defenestration']\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pv211_utils.preprocessing.text_preprocessing import DocPreprocessing\n",
+    "\n",
+    "# let us start with stop words\n",
+    "# you can add the stop words you wish and see how they disappear\n",
+    "my_stopwords = [\"and\", \"or\", \"not\", \"with\"] # \"how\", \"why\", \"to\", \"no\" ...\n",
+    "\n",
+    "preprocessor = DocPreprocessing(stopwords=my_stopwords)\n",
+    "tokens = preprocessor(sentence)\n",
+    "print(\"Tokens with DocPreprocessing and the list of stopwords:\")\n",
+    "print(tokens)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Stemming \n",
+    "\n",
+    "Stemming is a text normalization technique that cuts words down to their root (not always the root in the linguistic sense) by removing common prefixes or suffixes. This helps group together words with the same core meaning, like running and runner → run, even if the resulting stems aren’t valid words. Stemming is fast and simple, making it a popular choice in information retrieval for improving search recall [Manning et al., Introduction to Information Retrieval, [Section 2.2](https://nlp.stanford.edu/IR-book/pdf/02voc.pdf)]."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Tokens with DocPreprocessing and the list of stopwords:\n",
+      "['what', 'nice', 'idea', 'sta', 'proje', 'days', 'befo', 'the', 'deadline.', 'hope', 'go', 'end', 'defenestrati']\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pv211_utils.preprocessing.text_preprocessing import DocPreprocessing\n",
+    "\n",
+    "# this is our own stemmer, but currently it is really stupid...\n",
+    "# feel free to try building your own stemmer, but be cautious: it's a challenge!\n",
+    "\n",
+    "def dummy_stemmer(word):\n",
+    "    \"\"\"\n",
+    "    If the word is shorter than 5 letters, then we don't touch it.\n",
+    "    Otherwise checks if the word ends with \"s\", if it does - cuts \"s\" off.\n",
+    "    Also checks for the \"-ing\" ending and cuts it off.\n",
+    "    Otherwise just cuts off last 2 letters\n",
+    "    \n",
+    "    \"\"\"\n",
+    "    if len(word) < 5:\n",
+    "        return word\n",
+    "\n",
+    "    elif word.endswith(\"s\"):\n",
+    "        return word[:-1]\n",
+    "\n",
+    "    elif word.endswith(\"ing\"):\n",
+    "        return word[:-3]\n",
+    "\n",
+    "    else:\n",
+    "        return word[:-2]  \n",
+    "\n",
+    "preprocessor = DocPreprocessing(stem=dummy_stemmer, stopwords=my_stopwords)\n",
+    "tokens = preprocessor(sentence)\n",
+    "\n",
+    "print(\"Tokens with DocPreprocessing and the list of stopwords:\")\n",
+    "print(tokens)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Lemmatization\n",
+    "Lemmatization reduces words to their dictionary base form (lemma), so that variations like running and ran map to run. Unlike stemming, which simply chops endings, lemmatization uses linguistic rules and vocabulary knowledge, resulting in more meaningful normalization. This helps information retrieval systems better match related words and improves both recall and precision [Manning et al., Introduction to Information Retrieval, Section 2.2].\n",
+    "\n",
+    "Now let's try lematization imported from the NLTK library."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Collecting nltk\n",
+      "  Obtaining dependency information for nltk from https://files.pythonhosted.org/packages/4d/66/7d9e26593edda06e8cb531874633f7c2372279c3b0f46235539fe546df8b/nltk-3.9.1-py3-none-any.whl.metadata\n",
+      "  Using cached nltk-3.9.1-py3-none-any.whl.metadata (2.9 kB)\n",
+      "Collecting click (from nltk)\n",
+      "  Obtaining dependency information for click from https://files.pythonhosted.org/packages/85/32/10bb5764d90a8eee674e9dc6f4db6a0ab47c8c4d0d83c27f7c39ac415a4d/click-8.2.1-py3-none-any.whl.metadata\n",
+      "  Using cached click-8.2.1-py3-none-any.whl.metadata (2.5 kB)\n",
+      "Requirement already satisfied: joblib in c:\\users\\admin\\python311\\lib\\site-packages (from nltk) (1.4.2)\n",
+      "Requirement already satisfied: regex>=2021.8.3 in c:\\users\\admin\\python311\\lib\\site-packages (from nltk) (2024.11.6)\n",
+      "Requirement already satisfied: tqdm in c:\\users\\admin\\python311\\lib\\site-packages (from nltk) (4.67.1)\n",
+      "Requirement already satisfied: colorama in c:\\users\\admin\\appdata\\roaming\\python\\python311\\site-packages (from click->nltk) (0.4.6)\n",
+      "Using cached nltk-3.9.1-py3-none-any.whl (1.5 MB)\n",
+      "Using cached click-8.2.1-py3-none-any.whl (102 kB)\n",
+      "Installing collected packages: click, nltk\n",
+      "Successfully installed click-8.2.1 nltk-3.9.1\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "[notice] A new release of pip is available: 23.2.1 -> 25.2\n",
+      "[notice] To update, run: python.exe -m pip install --upgrade pip\n"
+     ]
+    }
+   ],
+   "source": [
+    "# first let's install nltk if not already installed\n",
+    "\n",
+    "!pip install nltk"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[nltk_data] Downloading package wordnet to\n",
+      "[nltk_data]     C:\\Users\\Admin\\AppData\\Roaming\\nltk_data...\n",
+      "[nltk_data]   Package wordnet is already up-to-date!\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import nltk\n",
+    "nltk.download('wordnet')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Tokens with DocPreprocessing + NLTK WordNet lemmatizer:\n",
+      "['what', 'nice', 'idea', 'start', 'project', 'day', 'before', 'the', 'deadline...', 'hope', 'going', 'end', 'defenestration']\n"
+     ]
+    }
+   ],
+   "source": [
+    "from nltk.stem import WordNetLemmatizer\n",
+    "from pv211_utils.preprocessing.text_preprocessing import DocPreprocessing\n",
+    "\n",
+    "# here we create the lemmatizer\n",
+    "wn_lemmatizer = WordNetLemmatizer()\n",
+    "\n",
+    "# wrapping it into a function matching DocPreprocessing's expected signature\n",
+    "def nltk_lemmatizer(word):\n",
+    "    return wn_lemmatizer.lemmatize(word)\n",
+    "\n",
+    "# create the preprocessor \n",
+    "preprocessor = DocPreprocessing(lemm=nltk_lemmatizer, stopwords=my_stopwords)\n",
+    "tokens = preprocessor(sentence)\n",
+    "print(\"Tokens with DocPreprocessing + NLTK WordNet lemmatizer:\")\n",
+    "print(tokens)\n",
+    "\n",
+    "# now look, we literally have lemmas on the output!\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Math Preprocessing"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "There are also some tools for preprocessing math expressions, especially useful in the [ARQMath](#arqmath-collection) task."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      " LaTeX representation:\n",
+      "x^{211} + 211 x + 211\n",
+      "\n",
+      " Presentation MathML:\n",
+      "<mrow><msup><mi>x</mi><mn>211</mn></msup><mo>+</mo><mrow><mn>211</mn><mo>&InvisibleTimes;</mo><mi>x</mi></mrow><mo>+</mo><mn>211</mn></mrow>\n",
+      "\n",
+      " Content MathML:\n",
+      "<apply><plus/><apply><power/><ci>x</ci><cn>211</cn></apply><apply><times/><cn>211</cn><ci>x</ci></apply><cn>211</cn></apply>\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Import your math utilities\n",
+    "from pv211_utils.preprocessing.math_preprocessing import (\n",
+    "    exp_to_latex, exp_to_pmathml, exp_to_cmathml\n",
+    ")\n",
+    "\n",
+    "# define a simple Python-style math expression (type in whatever you want)\n",
+    "expression = \"x**211 + 211*x + 211\"\n",
+    "\n",
+    "# convert to LaTeX\n",
+    "latex_output = exp_to_latex(expression)\n",
+    "print(\"\\n LaTeX representation:\")\n",
+    "print(latex_output)\n",
+    "\n",
+    "# convert to presentation MathML\n",
+    "pmathml_output = exp_to_pmathml(expression)\n",
+    "print(\"\\n Presentation MathML:\")\n",
+    "print(pmathml_output)\n",
+    "\n",
+    "# convert to content MathML\n",
+    "cmathml_output = exp_to_cmathml(expression)\n",
+    "print(\"\\n Content MathML:\")\n",
+    "print(cmathml_output)\n",
+    "\n",
+    "# "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Information Retrieval Systems from `systems` package"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `systems` package implements a complete suite of information retrieval (IR) components, from classical bag-of-words methods to modern neural reranking:\n",
+    "\n",
+    "Some of the tools use `gensim` library by Radim Řehůřek -> [Find out about gensim here](https://radimrehurek.com/gensim/)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# to work with this section, imports are needed:\n",
+    "\n",
+    "from pv211_utils.preprocessing.text_preprocessing import SimpleDocPreprocessing\n",
+    "from pv211_utils.entities import DocumentBase, QueryBase\n",
+    "from collections import OrderedDict"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Bag of Words \n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The Bag-of-Words (BoW) retrieval system is a foundational ranked retrieval method in information retrieval, representing both documents and queries as unordered collections of word frequencies. By reducing text to word counts, BoW captures the lexical content while discarding grammar and word order, allowing efficient comparison of textual similarity in high-dimensional vector spaces.\n",
+    "\n",
+    "For example, when a user submits a query like “the child makes the dog happy”, BoW tokenizes it into words and constructs a vector reflecting the frequency of each word (see below). Each document in the collection is likewise vectorized. The system then calculates a similarity measure (such as cosine similarity) between the query vector and every document vector, returning a ranked list of documents — those most lexically similar to the query appear first. \n",
+    "\n",
+    "*\"For ranked retrieval, the key idea of the vector space model is to represent queries and documents as vectors in a common term space and to rank documents according to their proximity to the query vector.\"*\n",
+    "\n",
+    "*— Manning et al., Introduction to Information Retrieval, [Section 6.3](https://nlp.stanford.edu/IR-book/pdf/06vect.pdf).*\n",
+    "\n",
+    "While BoW lacks semantic understanding or word order awareness, it is a strong baseline for building more advanced retrieval systems.\n",
+    "\n",
+    "\n",
+    "\n",
+    "![BoW](https://aiml.com/wp-content/uploads/2023/02/disadvantage-bow-1024x650.png)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# first let us import everything needed\n",
+    "from pv211_utils.systems.bow import BoWSystem"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let us demonstrate how this system works with a toy set of sentences and a made up query. The `entities` module helps us do it with `DocumentBase` and `QueryBase`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Building the dictionary: 100%|██████████| 5/5 [00:00<00:00, 4994.41it/s]\n",
+      "Building the index: 100%|██████████| 5/5 [00:00<?, ?it/s]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# defining a toy set of documents\n",
+    "documents = OrderedDict({\n",
+    "    \"doc1\": DocumentBase(\"doc1\", \"Cats are wonderful animals.\"),\n",
+    "    \"doc2\": DocumentBase(\"doc2\", \"Dogs are loyal pets.\"),\n",
+    "    \"doc3\": DocumentBase(\"doc3\", \"Birds can fly in the sky.\"),\n",
+    "    \"doc4\": DocumentBase(\"doc4\", \"Kittens are amazing creatures.\"),\n",
+    "    \"doc5\": DocumentBase(\"doc5\", \"I will have F on the Introduction to Information Retrieval\")\n",
+    "})\n",
+    "\n",
+    "# defining a simple preprocessing strategy \n",
+    "preprocessor = SimpleDocPreprocessing()\n",
+    "\n",
+    "# initializing the bag-of-words system with documents and preprocessing as arguments\n",
+    "bow_system = BoWSystem(documents, preprocessor)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "After running the BoW system on a query, we will see a list of documents from the most to the least relevant one. This is the output of ranked retrieval."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "retrieval results for the query:\n",
+      "- Document ID: doc1 | Content: Cats are wonderful animals.\n",
+      "- Document ID: doc2 | Content: Dogs are loyal pets.\n",
+      "- Document ID: doc4 | Content: Kittens are amazing creatures.\n",
+      "- Document ID: doc3 | Content: Birds can fly in the sky.\n",
+      "- Document ID: doc5 | Content: I will have F on the Introduction to Information Retrieval\n"
+     ]
+    }
+   ],
+   "source": [
+    "# creating a query (try to play around with it)\n",
+    "query = QueryBase(\"q1\", \"What are cats?\")\n",
+    "\n",
+    "# performing ranked retrieval for the query\n",
+    "print(\"retrieval results for the query:\")\n",
+    "for doc in bow_system.search(query):\n",
+    "    print(f\"- Document ID: {doc.document_id} | Content: {doc.body}\")\n",
+    "\n",
+    "\n",
+    "# NOTE: see how the sentence with cats and the sentence with kittens often don't appear together: the BoW system doesn't really understand that those are similar things"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## TF-IDF "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\n",
+    "The `TfidfSystem` implements a ranked retrieval model based on the Term Frequency–Inverse Document Frequency (TF-IDF) weighting scheme. This system represents both documents and queries as vectors in a high-dimensional space where each dimension corresponds to a term from the corpus vocabulary. By computing the cosine similarity between the query vector and document vectors, it ranks documents in order of their estimated relevance to the query.\n",
+    "\n",
+    "TF-IDF weighting helps emphasize words that are frequent in a specific document but rare across the entire collection — which intuitively captures the idea that such words are often **more informative**. For instance, in a collection of animal texts, words like “whiskers” or “purring” may help distinguish a document about cats, whereas common words like “animal” or “the” are in almost every document (as in the example in the code below) and these words carry little discriminative power.\n",
+    "\n",
+    "Manning et al. (2008) in [Chapter 6](https://nlp.stanford.edu/IR-book/pdf/06vect.pdf) highlight that “One of the most effective and widely used weighting schemes is tf-idf weighting.”\n",
+    "\n",
+    "\n",
+    "![TF IDF](https://www.seoquantum.com/sites/default/files/tf-idf-2-1-1024x375.png)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "ValueError",
+     "evalue": "cannot find context for 'fork'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+      "\u001b[31mValueError\u001b[39m                                Traceback (most recent call last)",
+      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[28]\u001b[39m\u001b[32m, line 14\u001b[39m\n\u001b[32m     11\u001b[39m preprocessor = SimpleDocPreprocessing()\n\u001b[32m     13\u001b[39m \u001b[38;5;66;03m# creating the TF-IDF system\u001b[39;00m\n\u001b[32m---> \u001b[39m\u001b[32m14\u001b[39m tfidf = \u001b[43mTfidfSystem\u001b[49m\u001b[43m(\u001b[49m\u001b[43mdocs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mpreprocessor\u001b[49m\u001b[43m)\u001b[49m\n",
+      "\u001b[36mFile \u001b[39m\u001b[32mc:\\Users\\Admin\\pv211-utils\\pv211_utils\\systems\\tfidf.py:37\u001b[39m, in \u001b[36mTfidfSystem.__init__\u001b[39m\u001b[34m(self, documents, preprocessing)\u001b[39m\n\u001b[32m     34\u001b[39m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34m__init__\u001b[39m(\u001b[38;5;28mself\u001b[39m, documents: OrderedDict[\u001b[38;5;28mstr\u001b[39m, DocumentBase], preprocessing: DocPreprocessingBase):\n\u001b[32m     35\u001b[39m     \u001b[38;5;28mself\u001b[39m.\u001b[34m__class__\u001b[39m.preprocessing = preprocessing\n\u001b[32m---> \u001b[39m\u001b[32m37\u001b[39m     \u001b[38;5;28;01mwith\u001b[39;00m \u001b[43mget_context\u001b[49m\u001b[43m(\u001b[49m\u001b[33;43m'\u001b[39;49m\u001b[33;43mfork\u001b[39;49m\u001b[33;43m'\u001b[39;49m\u001b[43m)\u001b[49m.Pool(\u001b[38;5;28;01mNone\u001b[39;00m) \u001b[38;5;28;01mas\u001b[39;00m pool:\n\u001b[32m     38\u001b[39m         document_bodies = pool.imap(\u001b[38;5;28mself\u001b[39m.\u001b[34m__class__\u001b[39m._document_to_tokens, documents.values())\n\u001b[32m     39\u001b[39m         document_bodies = tqdm(document_bodies, desc=\u001b[33m'\u001b[39m\u001b[33mBuilding the dictionary\u001b[39m\u001b[33m'\u001b[39m, total=\u001b[38;5;28mlen\u001b[39m(documents))\n",
+      "\u001b[36mFile \u001b[39m\u001b[32mc:\\Users\\Admin\\Python311\\Lib\\multiprocessing\\context.py:243\u001b[39m, in \u001b[36mDefaultContext.get_context\u001b[39m\u001b[34m(self, method)\u001b[39m\n\u001b[32m    241\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mself\u001b[39m._actual_context\n\u001b[32m    242\u001b[39m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[32m--> \u001b[39m\u001b[32m243\u001b[39m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43msuper\u001b[39;49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\u001b[43m.\u001b[49m\u001b[43mget_context\u001b[49m\u001b[43m(\u001b[49m\u001b[43mmethod\u001b[49m\u001b[43m)\u001b[49m\n",
+      "\u001b[36mFile \u001b[39m\u001b[32mc:\\Users\\Admin\\Python311\\Lib\\multiprocessing\\context.py:193\u001b[39m, in \u001b[36mBaseContext.get_context\u001b[39m\u001b[34m(self, method)\u001b[39m\n\u001b[32m    191\u001b[39m     ctx = _concrete_contexts[method]\n\u001b[32m    192\u001b[39m \u001b[38;5;28;01mexcept\u001b[39;00m \u001b[38;5;167;01mKeyError\u001b[39;00m:\n\u001b[32m--> \u001b[39m\u001b[32m193\u001b[39m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m(\u001b[33m'\u001b[39m\u001b[33mcannot find context for \u001b[39m\u001b[38;5;132;01m%r\u001b[39;00m\u001b[33m'\u001b[39m % method) \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m\n\u001b[32m    194\u001b[39m ctx._check_available()\n\u001b[32m    195\u001b[39m \u001b[38;5;28;01mreturn\u001b[39;00m ctx\n",
+      "\u001b[31mValueError\u001b[39m: cannot find context for 'fork'"
+     ]
+    }
+   ],
+   "source": [
+    "from pv211_utils.systems.tfidf import TfidfSystem\n",
+    "\n",
+    "# preparing documents\n",
+    "docs = OrderedDict({\n",
+    "    \"doc1\": DocumentBase(\"doc1\", \"Cats are playful and curious animals.\"),\n",
+    "    \"doc2\": DocumentBase(\"doc2\", \"Dogs are loyal and protective animals.\"),\n",
+    "    \"doc3\": DocumentBase(\"doc3\", \"Birds are also animals but they can fly.\"),\n",
+    "})\n",
+    "\n",
+    "# creating a simple preprocessor (lowercasing + tokenization)\n",
+    "preprocessor = SimpleDocPreprocessing()\n",
+    "\n",
+    "# creating the TF-IDF system\n",
+    "tfidf = TfidfSystem(docs, preprocessor)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'tfidf' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+      "\u001b[31mNameError\u001b[39m                                 Traceback (most recent call last)",
+      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[17]\u001b[39m\u001b[32m, line 5\u001b[39m\n\u001b[32m      2\u001b[39m query = QueryBase(\u001b[33m\"\u001b[39m\u001b[33mq1\u001b[39m\u001b[33m\"\u001b[39m, \u001b[33m\"\u001b[39m\u001b[33mplayful pets\u001b[39m\u001b[33m\"\u001b[39m)\n\u001b[32m      4\u001b[39m \u001b[38;5;66;03m# searching with the query\u001b[39;00m\n\u001b[32m----> \u001b[39m\u001b[32m5\u001b[39m results = \u001b[38;5;28mlist\u001b[39m(\u001b[43mtfidf\u001b[49m.search(query))\n\u001b[32m      7\u001b[39m \u001b[38;5;66;03m# printing top results\u001b[39;00m\n\u001b[32m      8\u001b[39m \u001b[38;5;28;01mfor\u001b[39;00m rank, doc \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28menumerate\u001b[39m(results[:\u001b[32m3\u001b[39m], \u001b[32m1\u001b[39m):\n",
+      "\u001b[31mNameError\u001b[39m: name 'tfidf' is not defined"
+     ]
+    }
+   ],
+   "source": [
+    "# preparing query\n",
+    "query = QueryBase(\"q1\", \"Protective animals\")\n",
+    "\n",
+    "# searching with the query\n",
+    "results = list(tfidf.search(query))\n",
+    "\n",
+    "# printing top results\n",
+    "for rank, doc in enumerate(results[:3], 1):\n",
+    "    print(f\"Rank {rank}: Document ID {doc.document_id} -> {doc.body}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## BM25"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "BM25 (and its extension BM25+) is one of the most effective ranking functions in modern information retrieval. \n",
+    "\n",
+    "*\"“BM25 is one of the best known and most widely used retrieval functions in modern IR systems.”\"*\n",
+    "*— Manning et al., Introduction to Information Retrieval, [Section 11.4](https://nlp.stanford.edu/IR-book/pdf/11prob.pdf).*\n",
+    "\n",
+    "It builds on TF-IDF by capturing both term frequency saturation and document length normalization, which helps fairly compare shorter and longer documents. In simple terms, BM25 recognizes that longer documents have more words and might match queries more often by chance — so it adjusts scores for document length to prevent unfairly favoring long texts. This solves a problem that is quite a drawback for TF-IDF.\n",
+    "\n",
+    "The scoring formula rewards terms appearing more frequently in documents but applies diminishing returns (term frequency saturation), and adjusts relevance based on how the document length deviates from the average document length in the corpus (via the parameter b). BM25+ also introduces a small delta parameter d to handle cases where raw BM25 can give negative scores.\n",
+    "\n",
+    "This makes BM25 (and BM25+) better than basic TF-IDF especially in real-world settings where documents vary greatly in length (e.g., product reviews, news articles, forum posts).\n",
+    "\n",
+    "**->** BM25+ is an extension of BM25 that adds a delta parameter to address BM25’s bias against very short documents, ensuring these documents can still achieve meaningful scores even if they contain important query terms.\n",
+    "\n",
+    "\n",
+    "Here is a nice explanation of the scary BM25's formula. \n",
+    "\n",
+    "**Lucene is a search engine library*\n",
+    "![bm25](https://kmwllc.com/wp-content/uploads/2021/05/bm25demystified-1536x662.png)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Ranked documents by BM25+:\n",
+      "1. Document ID: doc1 - Document snippet: Cats are cute....\n",
+      "2. Document ID: doc2 - Document snippet: Cats are wonderful pets that are loved by many people all ov...\n",
+      "3. Document ID: doc3 - Document snippet: Dogs are loyal and protective animals....\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pv211_utils.systems.bm25 import BM25PlusSystem\n",
+    "\n",
+    "# creating documents with very different lengths but similar content\n",
+    "docs = OrderedDict({\n",
+    "    \"doc1\": DocumentBase(\"doc1\", \"Cats are cute.\"),\n",
+    "    \"doc2\": DocumentBase(\"doc2\", \"Cats are wonderful pets that are loved by many people all over the world. They are known for their independence, playfulness, and affectionate behavior. Cats can be great companions in apartments and houses.\"),\n",
+    "    \"doc3\": DocumentBase(\"doc3\", \"Dogs are loyal and protective animals.\"),\n",
+    "})\n",
+    "\n",
+    "# creating a query about cats\n",
+    "query = QueryBase(\"query1\", \"cats are affectionate\")\n",
+    "\n",
+    "# creating a simple preprocessor\n",
+    "preprocessor = SimpleDocPreprocessing()\n",
+    "\n",
+    "# creating the BM25+ system\n",
+    "bm25_system = BM25PlusSystem(docs, preprocessor)\n",
+    "\n",
+    "# searching with the query\n",
+    "results = list(bm25_system.search(query))\n",
+    "\n",
+    "# printing ranked results\n",
+    "print(\"Ranked documents by BM25+:\")\n",
+    "for rank, doc in enumerate(results, start=1):\n",
+    "    print(f\"{rank}. Document ID: {doc.document_id} - Document snippet: {doc.body[:60]}...\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Dense Retrieval Systems with `retriever` module"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\n",
+    "Systems that we looked at before (such BoW, TF-IDF, or BM25) rely purely on token frequency statistics when trying to capture word representations. In a retrieval system they will find the needed sentence only if the needed keyword (or its normalized version) is present there. These systems are called sparse retrievers. Now we will look at dense retrievers: they use neural embeddngs pretrained on large amounts of data. They capture the semantic meaning of the words. For example, such retreivers can see similarity between words \"lesson\" and \"lecture\", even though they are quite different. A great and famous example of such models are BERT models. You can find out more about them by following these links:\n",
+    "\n",
+    "**Here are some useful links to read about BERT models:**\n",
+    "\n",
+    "**-> [Demonstration of BERT with code](https://huggingface.co/docs/transformers/en/model_doc/bert) on HuggingFace**\n",
+    "\n",
+    "**-> [BERT: A Comprehensive Introduction](https://medium.com/@lixue421/bert-a-comprehensive-introduction-7d620efcd32f)** on Medium\n",
+    "\n",
+    "**-> [Article about BERT](https://en.wikipedia.org/wiki/BERT_(language_model))** on Wikipedia\n",
+    "\n",
+    "**-> The original paper: [BERT: Pre-training of Deep Bidirectional Transformers for Language Understanding](https://arxiv.org/abs/1810.04805)** by J. Devlin et al.(2019)\n",
+    "\n",
+    "\n",
+    "After loading the `RetrieverSystem` from the `retriever.py` module, feel free to experiment by adding pretrained models. Below is a code snippet with a demonstration of how it works."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Top retrieved document ID: doc1\n",
+      "Document text: The capital of France is Paris.\n"
+     ]
+    }
+   ],
+   "source": [
+    "from sentence_transformers import SentenceTransformer\n",
+    "from pv211_utils.systems.retriever import RetrieverSystem\n",
+    "\n",
+    "# loading a small Sentence-BERT model (feel free to choose your own can be found on HuggingFace)\n",
+    "model = SentenceTransformer('paraphrase-MiniLM-L6-v2')\n",
+    "\n",
+    "# preparing documents\n",
+    "docs = OrderedDict({\n",
+    "    \"doc1\": DocumentBase(\"doc1\", \"The capital of France is Paris.\"),\n",
+    "    \"doc2\": DocumentBase(\"doc2\", \"Berlin is the capital of Germany.\"),\n",
+    "    \"doc3\": DocumentBase(\"doc3\", \"Madrid is the capital of Spain.\"),\n",
+    "})\n",
+    "\n",
+    "retriever = RetrieverSystem(model, docs)\n",
+    "\n",
+    "# defining a query that doesn't contain same words but is related to France\n",
+    "query = QueryBase(\"q1\", \"Where is the Eiffel Tower located?\")\n",
+    "\n",
+    "# performing the search + prints\n",
+    "results = list(retriever.search(query))\n",
+    "print(f\"Top retrieved document ID: {results[0].document_id}\")\n",
+    "print(f\"Document text: {results[0].body}\")\n",
+    "\n",
+    "# if you didn't change anything, you should get the doc1 as the best match. Bien joué!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `RetrieverSystem` class also allows to use the `query expansion` technique. This useful technique is also discussed in [Manning et al. Chapter 9.](https://nlp.stanford.edu/IR-book/pdf/09expand.pdf).   \n",
+    "\n",
+    "Query expansion is used to automatically enrich a user’s query with extra, relevant terms. The idea behind it is simple: the original query might be too short and not represent the user's **information need**. That's why we want to enrich it by adding words or phrases that are likely to bring better resultss. But where can we get those words from? We can extract them from top documents that were already retrieved. The `search` function of the `RetrieverSystem` class chooses the best fit among the documents, then uses TF-DF to extract top-k sentences from this document. The class parameter `top_k_sentences` defines how many sentences will be added to the query. The number of iteration of this process is defined by `no_query_expansion`\n",
+    "\n",
+    "Below you can see how the results change if you use **query expansion**. See how documents 2 and 3 swapped after applying the query extension. This is because the document about Sam mentions donuts in several sentences."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 62,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Retrieval WITHOUT query expansion:\n",
+      "→ Doc 1: My friend is Sam. He really enjoys donuts and says they are healthy. Donuts mean...\n",
+      "→ Doc 3: Cats are perfect animals. They are also good friends. But you have to learn how ...\n",
+      "→ Doc 2: I enjoy donuts very much. Much better than any salad or fresh juice. Donuts mean...\n",
+      "→ Doc 4: Gambling doesn't have loosers. It only has quitters. Don't give up. ...\n",
+      "\n",
+      "Retrieval WITH query expansion:\n",
+      "→ Doc 1: My friend is Sam. He really enjoys donuts and says they are healthy. Donuts mean...\n",
+      "→ Doc 2: I enjoy donuts very much. Much better than any salad or fresh juice. Donuts mean...\n",
+      "→ Doc 3: Cats are perfect animals. They are also good friends. But you have to learn how ...\n",
+      "→ Doc 4: Gambling doesn't have loosers. It only has quitters. Don't give up. ...\n"
+     ]
+    }
+   ],
+   "source": [
+    "from collections import OrderedDict\n",
+    "from sentence_transformers import SentenceTransformer\n",
+    "from pv211_utils.entities import DocumentBase, QueryBase\n",
+    "from pv211_utils.systems.retriever import RetrieverSystem\n",
+    "\n",
+    "# documents with multi-sentence content, but only some sentences are directly relevant\n",
+    "docs = OrderedDict({\n",
+    "    \"1\": DocumentBase(\"1\", \n",
+    "        \"My friend is Sam. \"\n",
+    "        \"He really enjoys donuts and says they are healthy. \"\n",
+    "        \"Donuts mean everything to him. \"\n",
+    "    ),\n",
+    "    \"2\": DocumentBase(\"2\", \n",
+    "        \"I enjoy donuts very much. \"\n",
+    "        \"Much better than any salad or fresh juice. \"\n",
+    "        \"Donuts mean everything to me. \"\n",
+    "    ),\n",
+    "    \"3\": DocumentBase(\"3\", \n",
+    "        \"Cats are perfect animals. \"\n",
+    "        \"They are also good friends. \"\n",
+    "        \"But you have to learn how to treat them.\"\n",
+    "    ),\n",
+    "    \"4\": DocumentBase(\"4\", \n",
+    "        \"Gambling doesn't have loosers. \"\n",
+    "        \"It only has quitters. \"\n",
+    "        \"Don't give up. \"\n",
+    "    ),\n",
+    "})\n",
+    "\n",
+    "# loading the dense retriever\n",
+    "retriever_model = SentenceTransformer(\"all-MiniLM-L6-v2\")\n",
+    "\n",
+    "# defining the user query\n",
+    "query = QueryBase(\"q1\", \"Sam is my friend. \")\n",
+    "\n",
+    "# running retriever without query expansion\n",
+    "print(\"Retrieval WITHOUT query expansion:\")\n",
+    "retriever_no_exp = RetrieverSystem(\n",
+    "    retriever=retriever_model,\n",
+    "    answers=docs,\n",
+    "    no_query_expansion=0\n",
+    ")\n",
+    "results_no_exp = list(retriever_no_exp.search(query))\n",
+    "for doc in results_no_exp:\n",
+    "    print(f\"→ Doc {doc.document_id}: {doc.body[:80]}...\")\n",
+    "\n",
+    "# running retriever with query expansion\n",
+    "print(\"\\nRetrieval WITH query expansion:\")\n",
+    "retriever_with_exp = RetrieverSystem(\n",
+    "    retriever=retriever_model,\n",
+    "    answers=docs,\n",
+    "    no_query_expansion=1,  # enabling query expansion\n",
+    "    top_k_sentences=3\n",
+    ")\n",
+    "results_with_exp = list(retriever_with_exp.search(query))\n",
+    "for doc in results_with_exp:\n",
+    "    print(f\"→ Doc {doc.document_id}: {doc.body[:80]}...\")\n",
+    "\n",
+    "# see how Doc2 and Doc3 swapped places. Try to understand why."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Hybrid Retreval Systems with `ranker` and `reranker `\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now, we move beyond individual models to retrieval and ranking systems, which bring everything together to answer queries by efficiently searching a large collection of documents.\n",
+    "\n",
+    "Modern IR pipelines often use a two-stage architecture:\n",
+    "\n",
+    "##### 1️. Retriever stage (Dense retrieval) \n",
+    "– Quickly narrows down thousands or millions of candidate documents to the most promising ones using vector similarities.\n",
+    "##### 2️. Reranker stage (Cross-encoder reranking) \n",
+    "– Precisely scores the top candidates by jointly considering the full text of each document and the query.\n",
+    "\n",
+    "\n",
+    "Both systems that we have (`RankerSystem` and `RerankerSystem`) use this architecture, but in slightly different ways. \n",
+    "\n",
+    "##### `RerankerSystem` \n",
+    "1. encodes all documents with a SentenceTransformer and stores their embeddings in memory.\n",
+    "\n",
+    "2. computes cosine similarities directly between the query embedding and all stored document embeddings.\n",
+    "\n",
+    "3. selects the top candidates based on similarity scores and reranks them using a CrossEncoder*\n",
+    "*CrossEncoder jointly scores query-document pairs for deeper semantic understanding.\n",
+    "\n",
+    "4. returns documents in the reranked order.\n",
+    "\n",
+    "##### `RankerSystem`\n",
+    "\n",
+    "Like RerankerSystem, it encodes all documents using a SentenceTransformer.\n",
+    "\n",
+    "1. instead of storing embeddings in memory, it adds them to a vector database (e.g., FAISS or your own implementation)\n",
+    "\n",
+    "2. at query time, it performs fast approximate nearest neighbor (ANN) search in the vector DB to retrieve top-k candidates.\n",
+    "\n",
+    "3. reranks the top documents with a CrossEncoder for precise scoring.\n",
+    "\n",
+    "\n",
+    "**-> In general, `RerankerSystem` is more simple, mostly because it doesn't use an external Vector DB. In case with `RankerSystem` it is scalable and better for lagr-scale data (millions of documents)**\n",
+    "\n",
+    "Here are some quick demonstrations of the `RerankerSystem` with code...\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "4dd2cfeb9b0a430ab8b758f7544075de",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "README.md: 0.00B [00:00, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from sentence_transformers import SentenceTransformer, CrossEncoder\n",
+    "\n",
+    "# let's create a nice minimal DocumentBase subclass\n",
+    "class SimpleDoc(DocumentBase):\n",
+    "    def __init__(self, doc_id: str, text: str):\n",
+    "        self.doc_id = doc_id\n",
+    "        self.text = text\n",
+    "    \n",
+    "    def __str__(self):\n",
+    "        return self.text\n",
+    "\n",
+    "answers = OrderedDict({\n",
+    "    \"1\": SimpleDoc(\"1\", \"The Eiffel Tower is in Paris.\"),\n",
+    "    \"2\": SimpleDoc(\"2\", \"The Great Wall can be seen from space.\"),\n",
+    "    \"3\": SimpleDoc(\"3\", \"Mount Everest is the tallest mountain.\"),\n",
+    "    \"4\": SimpleDoc(\"4\", \"I really like baguette.\"),\n",
+    "    \"5\": SimpleDoc(\"5\", \"I have never been to Lyon or Bordeaux\")\n",
+    "})\n",
+    "\n",
+    "# here load retriever and reranker models: feel free to experiment with your own\n",
+    "retriever = SentenceTransformer(\"all-MiniLM-L6-v2\")\n",
+    "reranker = CrossEncoder(\"cross-encoder/ms-marco-MiniLM-L-6-v2\")\n",
+    "\n",
+    "# making the query document\n",
+    "query = SimpleDoc(\"q1\", \"Do you like France?\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      " RerankerSystem Results:\n",
+      "- I have never been to Lyon or Bordeaux\n",
+      "- I really like baguette.\n",
+      "- The Eiffel Tower is in Paris.\n",
+      "- The Great Wall can be seen from space.\n",
+      "- Mount Everest is the tallest mountain.\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pv211_utils.systems.reranker import RerankerSystem  \n",
+    "\n",
+    "reranker_sys = RerankerSystem(\n",
+    "    retriever=retriever,\n",
+    "    reranker=reranker,\n",
+    "    answers=answers,\n",
+    "    no_reranks=2\n",
+    ")\n",
+    "\n",
+    "results = list(reranker_sys.search(query))\n",
+    "print(\"\\n RerankerSystem Results:\")\n",
+    "for doc in results:\n",
+    "    print(\"-\", doc)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3.11.6 64-bit",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.6"
+  },
+  "orig_nbformat": 4,
+  "vscode": {
+   "interpreter": {
+    "hash": "9568d3ddc277fe8802d3d59eb922a0a63a02bb2ac49fb2105baa38e6dfc5ff42"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This is a walkthrough that can help students navigate the repository in the beginning of the course. It should make the starting process easier and not only describe, but also make a quick demo of the functionality included in the pv211-utils.

1. For every project (Cranfield, ARQMath, CQADupStack, TREC) there is a brief description and demo code snippet. It lets the user see the data and extract it from the given dataset. 
2. There is a section on how to use datasets.py module to load data.
3. Text Preprocessing techniques such as lemmatization and stemming are demonstrated with examples.
4. Full demo of the systems package with code snippets to better understand how this package helps in retrieval tasks.
5. All the contents of the repo are (to the possible extent) mapped to Manning et al. 2008 book, with direct links to the book sections.
6. Extra links and useful sources (like articles about BERT) are included. There may be need to include more/filter out the current ones.

I tried to look at it from students' perspective and really make something I would rather have when I just started the course, so I hope it's at least a bit helpful :)